### PR TITLE
Add repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "A DataLoader implementation with caching support using Keyv",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/akshitkrnagpal/keyv-dataloader.git"
+  },
   "files": [
     "dist",
     "index.js",


### PR DESCRIPTION
Fixes #2

Added the repository field to package.json to properly link the npm package to the GitHub repository. This will improve discoverability from npm.