### PR TITLE
Add engines field to package.json for Node.js compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   "author": "",
   "license": "MIT",
   "packageManager": "pnpm@10.4.1",
+  "engines": {
+    "node": ">=14.0.0"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.28.1",
     "@keyv/redis": "^4.3.2",


### PR DESCRIPTION
Fixes #4

Added an engines field to package.json to specify the supported Node.js versions. This helps users understand which Node.js versions are supported and will show warnings if they try to install with incompatible versions.